### PR TITLE
Dont reference browser globals on init

### DIFF
--- a/packages/svg-baker-runtime/src/browser-sprite.js
+++ b/packages/svg-baker-runtime/src/browser-sprite.js
@@ -69,7 +69,7 @@ export default class BrowserSprite extends Sprite {
         moveGradientsOutsideSymbol(symbolNode.parentNode);
       }
 
-      if (browser.isIE || browser.isEdge) {
+      if (browser.isIE() || browser.isEdge()) {
         evalStylesIEWorkaround(symbolNode);
       }
     });
@@ -102,7 +102,7 @@ export default class BrowserSprite extends Sprite {
     }
 
     if (typeof cfg.moveGradientsOutsideSymbol === 'undefined') {
-      config.moveGradientsOutsideSymbol = browser.isFirefox;
+      config.moveGradientsOutsideSymbol = browser.isFirefox();
     }
   }
 

--- a/packages/svg-baker-runtime/src/utils/browser-detector.js
+++ b/packages/svg-baker-runtime/src/utils/browser-detector.js
@@ -1,10 +1,8 @@
-const ua = navigator.userAgent;
-
 export default {
-  isChrome: /chrome/i.test(ua),
-  isFirefox: /firefox/i.test(ua),
+  isChrome: () => /chrome/i.test(navigator.userAgent),
+  isFirefox: () => /firefox/i.test(navigator.userAgent),
 
   // https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx
-  isIE: /msie/i.test(ua) || /trident/i.test(ua),
-  isEdge: /edge/i.test(ua)
+  isIE: () => /msie/i.test(navigator.userAgent) || /trident/i.test(navigator.userAgent),
+  isEdge: () => /edge/i.test(navigator.userAgent)
 };


### PR DESCRIPTION
This makes it easier to deal with server side rendering, allowing importing this library and then determining if rendering on the server. 
Otherwise simply importing this lib will cause window to be referenced.