### PR TITLE
extract-svg-sprite-webpack-plugin: support webpack 4

### DIFF
--- a/packages/extract-svg-sprite-webpack-plugin/lib/utils/replacer.js
+++ b/packages/extract-svg-sprite-webpack-plugin/lib/utils/replacer.js
@@ -38,6 +38,8 @@ module.exports = class Replacer {
     if (webpackVersion <= 3) {
       args.push(compilation.outputOptions);
       args.push(compilation.requestShortener);
+    } else if (webpackVersion >= 4) {
+      args.push(compilation.runtimeTemplate);
     }
 
     const cachedSource = module.source(...args);


### PR DESCRIPTION
This change is necessary for extract-svg-sprite-webpack-plugin to be compatible with webpack 4. In that version of webpack, the second argument to NormalModule.source is the runtime template used by the target compilation. If not provided, webpack code which attempts to use the runtime will fail. For instance, the HarmonyCompatibilityDependency class calls the defineEsModuleFlagStatement method on the runtime during source dependency creation.