### PR TITLE
Feat/mini css extract support

### DIFF
--- a/packages/extract-svg-sprite-webpack-plugin/lib/config.js
+++ b/packages/extract-svg-sprite-webpack-plugin/lib/config.js
@@ -33,7 +33,7 @@ module.exports = {
     selector: '',
     spriteClass: mixer.Sprite,
     spriteConfig: {
-      usageIdSuffix: '-usage'
+      usageIdSuffix: ''
     },
     spriteType: mixer.Sprite.TYPE,
     symbolClass: mixer.SpriteSymbol,

--- a/packages/extract-svg-sprite-webpack-plugin/lib/config.js
+++ b/packages/extract-svg-sprite-webpack-plugin/lib/config.js
@@ -32,7 +32,9 @@ module.exports = {
     runtimeGenerator: RuntimeGenerator,
     selector: '',
     spriteClass: mixer.Sprite,
-    spriteConfig: undefined,
+    spriteConfig: {
+      usageIdSuffix: '-usage'
+    },
     spriteType: mixer.Sprite.TYPE,
     symbolClass: mixer.SpriteSymbol,
     symbolId: '[name]'

--- a/packages/extract-svg-sprite-webpack-plugin/lib/loader.js
+++ b/packages/extract-svg-sprite-webpack-plugin/lib/loader.js
@@ -39,6 +39,7 @@ module.exports = function (content, sourcemap, meta = {}) {
   symbol.key = `${loader._module.request}___${loader._module.issuer.request}`;
 
   plugin.compiler.addSymbol(symbol);
+  plugin.prevResult = null;
 
   const runtime = new config.runtimeGenerator(symbol, config).generate();
 

--- a/packages/extract-svg-sprite-webpack-plugin/lib/plugin.js
+++ b/packages/extract-svg-sprite-webpack-plugin/lib/plugin.js
@@ -42,15 +42,14 @@ class ExtractSvgSpritePlugin {
     const { NAMESPACE } = config;
 
     // TODO refactor this ugly way to avoid double compilation when using extract-text-webpack-plugin
-    let prevResult;
     // eslint-disable-next-line arrow-body-style
     const compileSprites = compilation => {
       return (
-        prevResult
-          ? Promise.resolve(prevResult)
+        this.prevResult
+          ? Promise.resolve(this.prevResult)
           : this.compiler.compile(compilation)
       ).then(result => {
-        prevResult = result;
+        this.prevResult = result;
         return result;
       });
     };

--- a/packages/extract-svg-sprite-webpack-plugin/lib/utils/replacement-generator.js
+++ b/packages/extract-svg-sprite-webpack-plugin/lib/utils/replacement-generator.js
@@ -42,14 +42,14 @@ class ReplacementGenerator {
    * @return {Replacement}
    */
   static symbolUrl(symbol, config) {
-    const { filename, emit, spriteType } = config;
+    const { filename, emit, spriteType, sriteConfig } = config;
     let replaceTo;
 
     if (!filename || !emit) {
       replaceTo = `#${symbol.id}`;
     } else {
       replaceTo = spriteType === mixer.StackSprite.TYPE
-        ? `${filename}#${symbol.id}`
+        ? `${filename}#${symbol.id}${sriteConfig.usageIdSuffix}`
         : filename;
     }
 

--- a/packages/extract-svg-sprite-webpack-plugin/lib/utils/replacer.js
+++ b/packages/extract-svg-sprite-webpack-plugin/lib/utils/replacer.js
@@ -1,5 +1,7 @@
 const webpackVersion = parseInt(require('webpack/package.json').version, 10);
 
+const MINI_EXTRACT_MODULE_TYPE = 'css/mini-extract';
+
 module.exports = class Replacer {
   /**
    * @param {string} input
@@ -38,6 +40,7 @@ module.exports = class Replacer {
     if (webpackVersion <= 3) {
       args.push(compilation.outputOptions);
       args.push(compilation.requestShortener);
+      // eslint-disable-next-line no-magic-numbers
     } else if (webpackVersion >= 4) {
       args.push(compilation.runtimeTemplate);
     }
@@ -56,6 +59,19 @@ module.exports = class Replacer {
    * @return {NormalModule}
    */
   static replaceInModuleSource(module, replacements, compilation) {
+    if (module.type === MINI_EXTRACT_MODULE_TYPE) {
+      replacements.forEach(({ token, replaceTo }) => {
+        if (module.content.indexOf(token) < 0) {
+          return;
+        }
+
+        const regExp = new RegExp(token, 'g');
+
+        module.content = module.content.replace(regExp, replaceTo);
+      });
+      return module;
+    }
+
     const source = Replacer.getModuleReplaceSource(module, compilation);
     const originalSourceContent = module.originalSource().source();
 

--- a/packages/svg-mixer/lib/sprite-symbols-map.js
+++ b/packages/svg-mixer/lib/sprite-symbols-map.js
@@ -13,7 +13,12 @@ class SpriteSymbolsMap extends Map {
    * @param {Array<SpriteSymbol>} [symbols]
    */
   constructor(symbols = []) {
-    super(symbols.map(s => [s.id, s]));
+    super(symbols.map(s => {
+      if (!s.issuers) {
+        s.issuers = symbols.filter(sb => sb.id === s.id).map(sb => sb.module && sb.module.issuer);
+      }
+      return [s.id, s];
+    }));
   }
 
   /**


### PR DESCRIPTION
Hi! First of all, thanks for your work. svg-mixer has a lot of handy tools for svg manipulation.
Here I kindly want to propose some improvements. Feel free to criticize.
This PR fixes a number of issues related to extract-svg-sprite-webpack-plugin support for css-mini-extract-plugin:
- In the current state, symbol tokens are not replaced with sprite filename/id in the result css
- sprite does not update when new icons are added in watch mode
- when the same icon is required in many files, only one url in css file is replaced
