### PR TITLE
feat: add clipPath & mask to "move-from-symbol-to-root" transform defaults

### DIFF
--- a/packages/svg-baker/lib/transformations/move-from-symbol-to-root.js
+++ b/packages/svg-baker/lib/transformations/move-from-symbol-to-root.js
@@ -3,7 +3,7 @@ const clone = require('clone');
 
 // Fixes Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=353575
 const defaultConfig = {
-  tags: ['linearGradient', 'radialGradient', 'pattern']
+  tags: ['linearGradient', 'radialGradient', 'pattern', 'clipPath', 'mask']
 };
 
 function moveFromSymbolToRoot(config = null) {

--- a/packages/svg-baker/package.json
+++ b/packages/svg-baker/package.json
@@ -29,6 +29,6 @@
   },
   "scripts": {
     "lint": "eslint lib test",
-    "test": "nyc --reporter=lcov mocha -r ../../test/mocha-setup.js"
+    "test": "nyc --reporter=lcov mocha --recursive -r ../../test/mocha-setup.js"
   }
 }

--- a/packages/svg-baker/test/transformations/move-from-symbol-to-root.test.js
+++ b/packages/svg-baker/test/transformations/move-from-symbol-to-root.test.js
@@ -5,7 +5,7 @@ const t = utils.setupPluginTest(plugin);
 describe('svg-baker/transformations/move-from-symbol-to-root', () => {
   it('should work', () => t(
     undefined,
-    '<svg><symbol><defs><linearGradient></linearGradient></defs></symbol></svg>',
-    '<svg><symbol><defs></defs></symbol><linearGradient></linearGradient></svg>'
+    '<svg><symbol><defs><linearGradient></linearGradient><mask></mask><clipPath></clipPath></defs></symbol></svg>',
+    '<svg><symbol><defs></defs></symbol><linearGradient></linearGradient><mask></mask><clipPath></clipPath></svg>'
   ));
 });


### PR DESCRIPTION
Addressed:
https://github.com/kisenka/svg-sprite-loader/issues/288
https://github.com/kisenka/svg-sprite-loader/issues/325