### PR TITLE
Fix a typo in replacement-generator.js

### DIFF
--- a/packages/extract-svg-sprite-webpack-plugin/lib/utils/replacement-generator.js
+++ b/packages/extract-svg-sprite-webpack-plugin/lib/utils/replacement-generator.js
@@ -42,14 +42,14 @@ class ReplacementGenerator {
    * @return {Replacement}
    */
   static symbolUrl(symbol, config) {
-    const { filename, emit, spriteType, sriteConfig } = config;
+    const { filename, emit, spriteType, spriteConfig } = config;
     let replaceTo;
 
     if (!filename || !emit) {
       replaceTo = `#${symbol.id}`;
     } else {
       replaceTo = spriteType === mixer.StackSprite.TYPE
-        ? `${filename}#${symbol.id}${sriteConfig.usageIdSuffix}`
+        ? `${filename}#${symbol.id}${spriteConfig.usageIdSuffix}`
         : filename;
     }
 


### PR DESCRIPTION
Hi. As described in https://github.com/JetBrains/svg-mixer/issues/60#, without the fix somehow `stats.toString()` call on webpack's Stats Object crashes.

I can hardly imagine a simpler change so feel free to discard the PR if you want to fix it on your own :-).

Have a nice day.
