### PR TITLE
fix: style SVG sprites with 'display: none'

### DIFF
--- a/packages/svg-baker-runtime/src/sprite.config.js
+++ b/packages/svg-baker-runtime/src/sprite.config.js
@@ -6,6 +6,7 @@ export default {
   attrs: {
     [svg.name]: svg.uri,
     [xlink.name]: xlink.uri,
-    style: ['position: absolute', 'width: 0', 'height: 0'].join('; ')
+    style: ['position: absolute', 'width: 0', 'height: 0'].join('; '),
+    'aria-hidden': 'true'
   }
 };


### PR DESCRIPTION
Using 'display: none' causes the rendered SVG to not be interpreted by
screen readers and other accessibility tools. The previous styling,
while containing no visual component, would be handled by screen
readers.

This is important for tools that automate a11y compliance, such as axe
to avoid warnings and errors of the form:

     All page content must be contained by landmarks

With 'display: none', the SVG sprite element will be skipped over.

For details on what the browser a11y API considers, see:

https://www.w3.org/TR/wai-aria-1.1/#aria-hidden

> User agents determine an element's hidden status based on whether it
> is rendered, and the rendering is usually controlled by CSS. For
> example, an element whose display property is set to none is not
> rendered. An element is considered hidden if it, or any of its
> ancestors are not rendered or have their aria-hidden attribute value
> set to true.
>
> Authors MAY, with caution, use aria-hidden to hide visibly rendered
> content from assistive technologies only if the act of hiding this
> content is intended to improve the experience for users of assistive
> technologies by removing redundant or extraneous content.