### PR TITLE
Clarify default ID generation logic

### DIFF
--- a/packages/svg-mixer/README.md
+++ b/packages/svg-mixer/README.md
@@ -95,8 +95,9 @@ Stack sprite also has following options:
 
 > Type: `function(path: string, query: string = '') => string`
 
-Function to generate `<symbol id>` attribute. By default file name without extension is used.
+Function to generate `<symbol id>` attribute. 
 Accepts 2 arguments: absolute path to file and optional query string.
+Default implementation generates a [url slug](https://www.npmjs.com/package/url-slug) using filename (without extension) and query string.
 
 <a id="prettify"></a>
 ### `prettify`


### PR DESCRIPTION
Update README to clarify what the default ID generation logic does. 

I had previously been adding the ID to my source svgs with an svgo plugin, but svg-mixer was overriding those later in the build pipeline. I was confused as to why that would be as the output did not match the filename, as mentioned in the docs. This PR updates the docs to describe the current logic better.

btw thanks for svg-mixer!